### PR TITLE
Override for the default HttpStatusCode of BigBrotherExceptionMiddleware

### DIFF
--- a/src/Eshopworld.Web/BigBrotherExceptionMiddleware.cs
+++ b/src/Eshopworld.Web/BigBrotherExceptionMiddleware.cs
@@ -23,7 +23,7 @@
         /// <param name="next">The next <see cref="RequestDelegate"/> in the pipeline.</param>
         /// <param name="bigBrother">The <see cref="IBigBrother"/> that we want to stream exception telemetry to.</param>
         /// <param name="responseHttpStatusCodeOnException">The <see cref="HttpStatusCode"/> we want to return in the response when handling an exception.</param>
-        public BigBrotherExceptionMiddleware(RequestDelegate next, IBigBrother bigBrother, HttpStatusCode responseHttpStatusCodeOnException = HttpStatusCode.ServiceUnavailable)
+        public BigBrotherExceptionMiddleware(RequestDelegate next, IBigBrother bigBrother, HttpStatusCode responseHttpStatusCodeOnException = HttpStatusCode.InternalServerError)
         {
 
             Next = next;

--- a/src/Eshopworld.Web/BigBrotherMiddlewareExtensions.cs
+++ b/src/Eshopworld.Web/BigBrotherMiddlewareExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 
 namespace Eshopworld.Web
 {
@@ -16,9 +17,20 @@ namespace Eshopworld.Web
         /// <param name="builder">The builder that provides the mechanisms to configure an application's request pipeline.</param>
         /// <param name="responseHttpStatusCodeOnException">The <see cref="HttpStatusCode"/> we want to return in the response when handling an exception.</param>
         /// <returns>[FLUENT] the <paramref name="builder"/>.</returns>
-        public static IApplicationBuilder UseBigBrotherExceptionHandler(this IApplicationBuilder builder, HttpStatusCode responseHttpStatusCodeOnException = HttpStatusCode.ServiceUnavailable)
+        [Obsolete("Optional Status Code Response from the BigBrotherMiddleware will be removed in the next release. In favor of always returning HTTP 500")]
+        public static IApplicationBuilder UseBigBrotherExceptionHandler(this IApplicationBuilder builder, HttpStatusCode responseHttpStatusCodeOnException)
         {
             return builder.UseMiddleware<BigBrotherExceptionMiddleware>(responseHttpStatusCodeOnException);
+        }
+        
+        /// <summary>
+        /// Register the <see cref="IBigBrother"/> exception handling middleware into the MVC pipeline.
+        /// </summary>
+        /// <param name="builder">The builder that provides the mechanisms to configure an application's request pipeline.</param>
+        /// <returns>[FLUENT] the <paramref name="builder"/>.</returns>
+        public static IApplicationBuilder UseBigBrotherExceptionHandler(this IApplicationBuilder builder)
+        {
+            return builder.UseMiddleware<BigBrotherExceptionMiddleware>();
         }
     }
 }

--- a/src/Eshopworld.Web/BigBrotherMiddlewareExtensions.cs
+++ b/src/Eshopworld.Web/BigBrotherMiddlewareExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Eshopworld.Web
+﻿using System.Net;
+
+namespace Eshopworld.Web
 {
     using Core;
     using Microsoft.AspNetCore.Builder;
@@ -12,10 +14,11 @@
         /// Register the <see cref="IBigBrother"/> exception handling middleware into the MVC pipeline.
         /// </summary>
         /// <param name="builder">The builder that provides the mechanisms to configure an application's request pipeline.</param>
+        /// <param name="responseHttpStatusCodeOnException">The <see cref="HttpStatusCode"/> we want to return in the response when handling an exception.</param>
         /// <returns>[FLUENT] the <paramref name="builder"/>.</returns>
-        public static IApplicationBuilder UseBigBrotherExceptionHandler(this IApplicationBuilder builder)
+        public static IApplicationBuilder UseBigBrotherExceptionHandler(this IApplicationBuilder builder, HttpStatusCode responseHttpStatusCodeOnException = HttpStatusCode.ServiceUnavailable)
         {
-            return builder.UseMiddleware<BigBrotherExceptionMiddleware>();
+            return builder.UseMiddleware<BigBrotherExceptionMiddleware>(responseHttpStatusCodeOnException);
         }
     }
 }

--- a/src/Eshopworld.Web/Eshopworld.Web.csproj
+++ b/src/Eshopworld.Web/Eshopworld.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.3.2</Version>
+    <Version>2.3.0</Version>
     <PackageReleaseNotes>Allow override for the default HttpStatusCode of BigBrotherExceptionMiddleware</PackageReleaseNotes>
 
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/Eshopworld.Web/Eshopworld.Web.csproj
+++ b/src/Eshopworld.Web/Eshopworld.Web.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.2.2</Version>
-    <PackageReleaseNotes>add  autorest http client factory extensions</PackageReleaseNotes>
+    <Version>2.3.2</Version>
+    <PackageReleaseNotes>Allow override for the default HttpStatusCode of BigBrotherExceptionMiddleware</PackageReleaseNotes>
 
     <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>True</IsPackable>

--- a/src/Eshopworld.Web/Eshopworld.Web.csproj
+++ b/src/Eshopworld.Web/Eshopworld.Web.csproj
@@ -1,8 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.3.0</Version>
-    <PackageReleaseNotes>Allow override for the default HttpStatusCode of BigBrotherExceptionMiddleware</PackageReleaseNotes>
+    <Version>3.0.0</Version>
+    <PackageReleaseNotes>
+      Change the default HttpStatusCode of BigBrotherExceptionMiddleware to 500.
+      Allow override for the default HttpStatusCode of BigBrotherExceptionMiddleware.
+    </PackageReleaseNotes>
 
     <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>True</IsPackable>

--- a/src/Tests/Eshopworld.Web.Tests/AlwaysThrowsTestStartupWithInternalServerErrorStatusCode.cs
+++ b/src/Tests/Eshopworld.Web.Tests/AlwaysThrowsTestStartupWithInternalServerErrorStatusCode.cs
@@ -11,11 +11,11 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Eshopworld.Web.Tests
 {
-    public class AlwaysThrowsTestStartupWithInternalServerErrorStatusCode
+    public class AlwaysThrowsTestStartupWithServiceUnavailableErrorStatusCode
     {
         internal static readonly BigBrother Bb = new BigBrother("", "");
 
-        public AlwaysThrowsTestStartupWithInternalServerErrorStatusCode(IHostingEnvironment env)
+        public AlwaysThrowsTestStartupWithServiceUnavailableErrorStatusCode(IHostingEnvironment env)
         {
         }
 
@@ -27,7 +27,7 @@ namespace Eshopworld.Web.Tests
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
-            app.UseBigBrotherExceptionHandler(HttpStatusCode.InternalServerError);
+            app.UseBigBrotherExceptionHandler(HttpStatusCode.ServiceUnavailable);
 
             app.Run(async ctx =>
                         {

--- a/src/Tests/Eshopworld.Web.Tests/AlwaysThrowsTestStartupWithInternalServerErrorStatusCode.cs
+++ b/src/Tests/Eshopworld.Web.Tests/AlwaysThrowsTestStartupWithInternalServerErrorStatusCode.cs
@@ -1,18 +1,21 @@
 ﻿using System;
+using System.Net;
 using System.Threading.Tasks;
+
 using Eshopworld.Core;
 using Eshopworld.Telemetry;
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Eshopworld.Web.Tests
 {
-    public class AlwaysThrowsTestStartup
+    public class AlwaysThrowsTestStartupWithInternalServerErrorStatusCode
     {
         internal static readonly BigBrother Bb = new BigBrother("", "");
 
-        public AlwaysThrowsTestStartup(IHostingEnvironment env)
+        public AlwaysThrowsTestStartupWithInternalServerErrorStatusCode(IHostingEnvironment env)
         {
         }
 
@@ -24,7 +27,7 @@ namespace Eshopworld.Web.Tests
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
-            app.UseBigBrotherExceptionHandler();
+            app.UseBigBrotherExceptionHandler(HttpStatusCode.InternalServerError);
 
             app.Run(async ctx =>
                         {

--- a/src/Tests/Eshopworld.Web.Tests/BigBrotherExceptionMiddlewareTest.cs
+++ b/src/Tests/Eshopworld.Web.Tests/BigBrotherExceptionMiddlewareTest.cs
@@ -37,7 +37,7 @@ namespace Eshopworld.Web.Tests
         }
 
         [Fact, IsLayer0]
-        public async Task Default_HttpStatusCode_On_Exception_Is_ServiceUnavailable()
+        public async Task Default_HttpStatusCode_On_Exception_Is_InternalServerError()
         {
             var middleware = new BigBrotherExceptionMiddleware(context => throw new Exception(), Mock.Of<IBigBrother>());
             var httpContext = new DefaultHttpContext();
@@ -46,13 +46,13 @@ namespace Eshopworld.Web.Tests
             await middleware.Invoke(httpContext);
 
 
-            httpContext.Response.StatusCode.Should().Be((int)HttpStatusCode.ServiceUnavailable);
+            httpContext.Response.StatusCode.Should().Be((int)HttpStatusCode.InternalServerError);
         }
 
         [Fact, IsLayer0]
         public async Task HttpStatusCode_On_Exception_Is_The_One_Passed_On_Ctor()
         {
-            var statusCode = HttpStatusCode.InternalServerError;
+            var statusCode = HttpStatusCode.ServiceUnavailable;
 
             var middleware = new BigBrotherExceptionMiddleware(context => throw new Exception(), Mock.Of<IBigBrother>(), statusCode);
             var httpContext = new DefaultHttpContext();

--- a/src/Tests/Eshopworld.Web.Tests/BigBrotherExceptionMiddlewareTest.cs
+++ b/src/Tests/Eshopworld.Web.Tests/BigBrotherExceptionMiddlewareTest.cs
@@ -1,4 +1,9 @@
-﻿namespace Eshopworld.Web.Tests
+﻿using System.Net;
+
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Http.Internal;
+
+namespace Eshopworld.Web.Tests
 {
     using System;
     using FluentAssertions;
@@ -31,13 +36,43 @@
             blewUp.Should().BeTrue();
         }
 
+        [Fact, IsLayer0]
+        public async Task Default_HttpStatusCode_On_Exception_Is_ServiceUnavailable()
+        {
+            var middleware = new BigBrotherExceptionMiddleware(context => throw new Exception(), Mock.Of<IBigBrother>());
+            var httpContext = new DefaultHttpContext();
+            
+            
+            await middleware.Invoke(httpContext);
+
+
+            httpContext.Response.StatusCode.Should().Be((int)HttpStatusCode.ServiceUnavailable);
+        }
+
+        [Fact, IsLayer0]
+        public async Task HttpStatusCode_On_Exception_Is_The_One_Passed_On_Ctor()
+        {
+            var statusCode = HttpStatusCode.InternalServerError;
+
+            var middleware = new BigBrotherExceptionMiddleware(context => throw new Exception(), Mock.Of<IBigBrother>(), statusCode);
+            var httpContext = new DefaultHttpContext();
+            
+            
+            await middleware.Invoke(httpContext);
+
+
+            httpContext.Response.StatusCode.Should().Be((int)statusCode);
+        }
+
+
+
         public class Invoke
         {
             [Fact, IsLayer0]
             public async Task Test_ExceptionsAreHandled()
             {
                 var mockMiddleware = new Mock<BigBrotherExceptionMiddleware>(MockBehavior.Loose,
-                    new RequestDelegate(_ => throw new Exception("KABUM")), new Mock<IBigBrother>().Object);
+                    new RequestDelegate(_ => throw new Exception("KABUM")), new Mock<IBigBrother>().Object, null);
                 mockMiddleware.Setup(x => x.Invoke(It.IsAny<HttpContext>())).CallBase();
                 mockMiddleware.Setup(x => x.HandleException(It.IsAny<HttpContext>(), It.IsAny<Exception>()))
                     .Returns(Task.CompletedTask);

--- a/src/Tests/Eshopworld.Web.Tests/BigBrotherMiddlewareExtensionsTest.cs
+++ b/src/Tests/Eshopworld.Web.Tests/BigBrotherMiddlewareExtensionsTest.cs
@@ -58,9 +58,21 @@ namespace Eshopworld.Web.Tests
         }
 
         [Fact, IsLayer1]
+        public async Task Test_Overriden_MiddleWare_Returns_ServiceUnavailable()
+        {
+            var client = new TestServer(new WebHostBuilder().UseStartup<AlwaysThrowsTestStartupWithServiceUnavailableErrorStatusCode>()).CreateClient();
+            
+
+            var response = await client.GetAsync("/");
+
+
+            response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        }
+        
+        [Fact, IsLayer1]
         public async Task Test_MiddleWare_Returns_InternalServerError()
         {
-            var client = new TestServer(new WebHostBuilder().UseStartup<AlwaysThrowsTestStartupWithInternalServerErrorStatusCode>()).CreateClient();
+            var client = new TestServer(new WebHostBuilder().UseStartup<AlwaysThrowsTestStartup>()).CreateClient();
             
 
             var response = await client.GetAsync("/");

--- a/src/Tests/Eshopworld.Web.Tests/BigBrotherMiddlewareExtensionsTest.cs
+++ b/src/Tests/Eshopworld.Web.Tests/BigBrotherMiddlewareExtensionsTest.cs
@@ -1,4 +1,6 @@
-﻿namespace Eshopworld.Web.Tests
+﻿using System.Net;
+
+namespace Eshopworld.Web.Tests
 {
     using System;
     using System.Threading.Tasks;
@@ -53,6 +55,18 @@
                 await client.GetAsync("/");
                 blewUp.Should().BeTrue();
             }
+        }
+
+        [Fact, IsLayer1]
+        public async Task Test_MiddleWare_Returns_InternalServerError()
+        {
+            var client = new TestServer(new WebHostBuilder().UseStartup<AlwaysThrowsTestStartupWithInternalServerErrorStatusCode>()).CreateClient();
+            
+
+            var response = await client.GetAsync("/");
+
+
+            response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
         }
     }
 }


### PR DESCRIPTION
Hello, 

This PR is to allow to override the HttpStatusCode that is returned from BigBrotherExceptionMiddleware whenever it catches an exception.

At the moment it returns a 503 (Service Unavailable) according to the [RFC](https://tools.ietf.org/html/rfc7231#section-6.6.4) this code is used for situations where there is a infrastructure issue. 

On the SNKRS project we want to return a 500 (Internal Server Error) [RFC](https://tools.ietf.org/html/rfc7231#section-6.6.1) when there is an unhandled exception as we feel that the description on the RFC more accurately describes the situation of an unhandled exception.

I made sure to change the code in a way to not break compatibility with previous versions.

Regards
João Jesus