### PR TITLE
#54946 - migrate Web package to net core 3.1

### DIFF
--- a/src/Eshopworld.Web/Eshopworld.Web.csproj
+++ b/src/Eshopworld.Web/Eshopworld.Web.csproj
@@ -1,13 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>3.0.0</Version>
+    <Version>4.0.0-preview1</Version>
     <PackageReleaseNotes>
-      Change the default HttpStatusCode of BigBrotherExceptionMiddleware to 500.
-      Allow override for the default HttpStatusCode of BigBrotherExceptionMiddleware.
+      Support .NET Core 3.1
     </PackageReleaseNotes>
 
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>True</IsPackable>
     <PackageId>Eshopworld.Web</PackageId>
     <Title>Eshopworld.Web</Title>
@@ -26,21 +25,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eshopworld.Core" Version="2.1.2" />
-    <PackageReference Include="Eshopworld.DevOps" Version="4.2.0" />
-    <PackageReference Include="Eshopworld.Telemetry" Version="2.1.4" />
+    <PackageReference Include="Eshopworld.Core" Version="4.0.0" />
+    <PackageReference Include="Eshopworld.DevOps" Version="5.0.0-preview1" />
+    <PackageReference Include="Eshopworld.Telemetry" Version="3.1.0-preview1" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.10.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="3.4.664" />
-    <PackageReference Include="Microsoft.ServiceFabric.AspNetCore.Kestrel" Version="3.4.664" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
-    <PackageReference Include="System.Reactive" Version="4.2.0-preview.102" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.13.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.2" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.0.466" />
+    <PackageReference Include="Microsoft.ServiceFabric.AspNetCore.Kestrel" Version="4.0.466" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
+    <PackageReference Include="System.Reactive" Version="4.3.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
 </Project>

--- a/src/Eshopworld.Web/EswSslExtentions.cs
+++ b/src/Eshopworld.Web/EswSslExtentions.cs
@@ -74,7 +74,6 @@ namespace Eshopworld.Web
                                 if (cert == null)
                                     cert = GetCertificate(context.HostingEnvironment.EnvironmentName);
                                 listenOptions.UseHttps(cert);
-                                listenOptions.NoDelay = true;
                             }
                             catch (Exception ex)
                             {

--- a/src/Eshopworld.Web/IServiceCollectionExtensions.cs
+++ b/src/Eshopworld.Web/IServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging.Abstractions.Internal;
 
 namespace Eshopworld.Web
 {

--- a/src/Eshopworld.Web/NotificationChannelMiddleware.cs
+++ b/src/Eshopworld.Web/NotificationChannelMiddleware.cs
@@ -91,7 +91,7 @@ namespace Eshopworld.Web
                 using (var reader
                     = new StreamReader(context.Request.Body, Encoding.UTF8, true, 1024, true))
                 {
-                    var bodyStr = reader.ReadToEnd();
+                    var bodyStr = await reader.ReadToEndAsync();
 
                     _subject.OnNext((BaseNotification)JsonConvert.DeserializeObject(bodyStr, resolvedNotificationType,
                         _options.JsonSerializerSettings));

--- a/src/Eshopworld.Web/Telemetry/RequestTelemetryInitializer.cs
+++ b/src/Eshopworld.Web/Telemetry/RequestTelemetryInitializer.cs
@@ -7,7 +7,6 @@ using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Internal;
 
 namespace Eshopworld.Web.Telemetry
 {
@@ -81,7 +80,8 @@ namespace Eshopworld.Web.Telemetry
         /// <remarks>Calling this method converts the request body to a rewindable stream. The method will first read the body from the stream, process it via the selector, and then rewind the stream for downstream handling</remarks>
         protected static T DeserializeRequestBody<T>(HttpRequest request)
         {
-            request.EnableRewind();
+            // EnableBuffering is the equivalent of EnableRewind in asp.net core 3.1
+            request.EnableBuffering();
             try
             {
                 using (var reader = new StreamReader(request.Body, Encoding.UTF8, true, 1024, true))

--- a/src/Eshopworld.Web/TypeNameHelper.cs
+++ b/src/Eshopworld.Web/TypeNameHelper.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Eshopworld.Web
+{
+    /// <summary>
+    /// TypeNameHelper has been moved one-to-one from 'https://github.com/dotnet/extensions/blob/master/src/Shared/src/TypeNameHelper/TypeNameHelper.cs'.
+    /// The Previous versions of package 'Microsoft.Extensions.Configuration.Abstractions' exposed this type directly, it is now an internal one.
+    /// </summary>
+    /// <remarks>
+    /// It has been decided to copy this file for backward compatibility.
+    /// </remarks>
+    internal class TypeNameHelper
+    {
+        private const char DefaultNestedTypeDelimiter = '+';
+
+        private static readonly Dictionary<Type, string> _builtInTypeNames = new Dictionary<Type, string>
+        {
+            { typeof(void), "void" },
+            { typeof(bool), "bool" },
+            { typeof(byte), "byte" },
+            { typeof(char), "char" },
+            { typeof(decimal), "decimal" },
+            { typeof(double), "double" },
+            { typeof(float), "float" },
+            { typeof(int), "int" },
+            { typeof(long), "long" },
+            { typeof(object), "object" },
+            { typeof(sbyte), "sbyte" },
+            { typeof(short), "short" },
+            { typeof(string), "string" },
+            { typeof(uint), "uint" },
+            { typeof(ulong), "ulong" },
+            { typeof(ushort), "ushort" }
+        };
+
+        public static string GetTypeDisplayName(object item, bool fullName = true)
+        {
+            return item == null ? null : GetTypeDisplayName(item.GetType(), fullName);
+        }
+
+        /// <summary>
+        /// Pretty print a type name.
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/>.</param>
+        /// <param name="fullName"><c>true</c> to print a fully qualified name.</param>
+        /// <param name="includeGenericParameterNames"><c>true</c> to include generic parameter names.</param>
+        /// <param name="includeGenericParameters"><c>true</c> to include generic parameters.</param>
+        /// <param name="nestedTypeDelimiter">Character to use as a delimiter in nested type names</param>
+        /// <returns>The pretty printed type name.</returns>
+        public static string GetTypeDisplayName(Type type, bool fullName = true, bool includeGenericParameterNames = false, bool includeGenericParameters = true, char nestedTypeDelimiter = DefaultNestedTypeDelimiter)
+        {
+            var builder = new StringBuilder();
+            ProcessType(builder, type, new DisplayNameOptions(fullName, includeGenericParameterNames, includeGenericParameters, nestedTypeDelimiter));
+            return builder.ToString();
+        }
+
+        private static void ProcessType(StringBuilder builder, Type type, in DisplayNameOptions options)
+        {
+            if (type.IsGenericType)
+            {
+                var genericArguments = type.GetGenericArguments();
+                ProcessGenericType(builder, type, genericArguments, genericArguments.Length, options);
+            }
+            else if (type.IsArray)
+            {
+                ProcessArrayType(builder, type, options);
+            }
+            else if (_builtInTypeNames.TryGetValue(type, out var builtInName))
+            {
+                builder.Append(builtInName);
+            }
+            else if (type.IsGenericParameter)
+            {
+                if (options.IncludeGenericParameterNames)
+                {
+                    builder.Append(type.Name);
+                }
+            }
+            else
+            {
+                var name = options.FullName ? type.FullName : type.Name;
+                builder.Append(name);
+
+                if (options.NestedTypeDelimiter != DefaultNestedTypeDelimiter)
+                {
+                    builder.Replace(DefaultNestedTypeDelimiter, options.NestedTypeDelimiter, builder.Length - name.Length, name.Length);
+                }
+            }
+        }
+
+        private static void ProcessArrayType(StringBuilder builder, Type type, in DisplayNameOptions options)
+        {
+            var innerType = type;
+            while (innerType.IsArray)
+            {
+                innerType = innerType.GetElementType();
+            }
+
+            ProcessType(builder, innerType, options);
+
+            while (type.IsArray)
+            {
+                builder.Append('[');
+                builder.Append(',', type.GetArrayRank() - 1);
+                builder.Append(']');
+                type = type.GetElementType();
+            }
+        }
+
+        private static void ProcessGenericType(StringBuilder builder, Type type, Type[] genericArguments, int length, in DisplayNameOptions options)
+        {
+            var offset = 0;
+            if (type.IsNested)
+            {
+                offset = type.DeclaringType.GetGenericArguments().Length;
+            }
+
+            if (options.FullName)
+            {
+                if (type.IsNested)
+                {
+                    ProcessGenericType(builder, type.DeclaringType, genericArguments, offset, options);
+                    builder.Append(options.NestedTypeDelimiter);
+                }
+                else if (!string.IsNullOrEmpty(type.Namespace))
+                {
+                    builder.Append(type.Namespace);
+                    builder.Append('.');
+                }
+            }
+
+            var genericPartIndex = type.Name.IndexOf('`');
+            if (genericPartIndex <= 0)
+            {
+                builder.Append(type.Name);
+                return;
+            }
+
+            builder.Append(type.Name, 0, genericPartIndex);
+
+            if (options.IncludeGenericParameters)
+            {
+                builder.Append('<');
+                for (var i = offset; i < length; i++)
+                {
+                    ProcessType(builder, genericArguments[i], options);
+                    if (i + 1 == length)
+                    {
+                        continue;
+                    }
+
+                    builder.Append(',');
+                    if (options.IncludeGenericParameterNames || !genericArguments[i + 1].IsGenericParameter)
+                    {
+                        builder.Append(' ');
+                    }
+                }
+                builder.Append('>');
+            }
+        }
+
+        private readonly struct DisplayNameOptions
+        {
+            public DisplayNameOptions(bool fullName, bool includeGenericParameterNames, bool includeGenericParameters, char nestedTypeDelimiter)
+            {
+                FullName = fullName;
+                IncludeGenericParameters = includeGenericParameters;
+                IncludeGenericParameterNames = includeGenericParameterNames;
+                NestedTypeDelimiter = nestedTypeDelimiter;
+            }
+
+            public bool FullName { get; }
+
+            public bool IncludeGenericParameters { get; }
+
+            public bool IncludeGenericParameterNames { get; }
+
+            public char NestedTypeDelimiter { get; }
+        }
+    }
+}

--- a/src/Tests/Eshopworld.Web.Tests/AlwaysThrowsTestStartup.cs
+++ b/src/Tests/Eshopworld.Web.Tests/AlwaysThrowsTestStartup.cs
@@ -12,7 +12,7 @@ namespace Eshopworld.Web.Tests
     {
         internal static readonly BigBrother Bb = new BigBrother("", "");
 
-        public AlwaysThrowsTestStartup(IHostingEnvironment env)
+        public AlwaysThrowsTestStartup(IWebHostEnvironment env)
         {
         }
 
@@ -22,7 +22,7 @@ namespace Eshopworld.Web.Tests
             return services.BuildServiceProvider();
         }
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             app.UseBigBrotherExceptionHandler();
 

--- a/src/Tests/Eshopworld.Web.Tests/AlwaysThrowsTestStartupWithInternalServerErrorStatusCode.cs
+++ b/src/Tests/Eshopworld.Web.Tests/AlwaysThrowsTestStartupWithInternalServerErrorStatusCode.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net;
 using System.Threading.Tasks;
 
@@ -15,7 +15,7 @@ namespace Eshopworld.Web.Tests
     {
         internal static readonly BigBrother Bb = new BigBrother("", "");
 
-        public AlwaysThrowsTestStartupWithServiceUnavailableErrorStatusCode(IHostingEnvironment env)
+        public AlwaysThrowsTestStartupWithServiceUnavailableErrorStatusCode(IWebHostEnvironment env)
         {
         }
 
@@ -25,7 +25,7 @@ namespace Eshopworld.Web.Tests
             return services.BuildServiceProvider();
         }
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             app.UseBigBrotherExceptionHandler(HttpStatusCode.ServiceUnavailable);
 

--- a/src/Tests/Eshopworld.Web.Tests/AutoRestExtensionsTests.cs
+++ b/src/Tests/Eshopworld.Web.Tests/AutoRestExtensionsTests.cs
@@ -34,7 +34,7 @@ namespace Eshopworld.Web.Tests
                 return services.BuildServiceProvider();
             }
 
-            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
             {
             }
         }

--- a/src/Tests/Eshopworld.Web.Tests/BigBrotherExceptionMiddlewareTest.cs
+++ b/src/Tests/Eshopworld.Web.Tests/BigBrotherExceptionMiddlewareTest.cs
@@ -1,11 +1,7 @@
-﻿using System.Net;
-
-using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.Http.Internal;
-
-namespace Eshopworld.Web.Tests
+﻿namespace Eshopworld.Web.Tests
 {
     using System;
+    using System.Net;
     using FluentAssertions;
     using Eshopworld.Tests.Core;
     using Microsoft.AspNetCore.Http;

--- a/src/Tests/Eshopworld.Web.Tests/Eshopworld.Web.Tests.csproj
+++ b/src/Tests/Eshopworld.Web.Tests/Eshopworld.Web.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <DebugType>Full</DebugType>
     <SonarQubeTestProject>true</SonarQubeTestProject>
@@ -10,20 +10,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.6.3">
+    <PackageReference Include="coverlet.msbuild" Version="2.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Eshopworld.Core" Version="2.1.2" />
+    <PackageReference Include="Eshopworld.Core" Version="4.0.0" />
     <PackageReference Include="EShopworld.Security.Services.Testing" Version="1.0.3" />
-    <PackageReference Include="Eshopworld.Telemetry" Version="2.1.4" />
+    <PackageReference Include="Eshopworld.Telemetry" Version="3.1.0-preview1" />
     <PackageReference Include="Eshopworld.Tests.Core" Version="1.1.1" />
-    <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="2.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -32,6 +30,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Eshopworld.Web\Eshopworld.Web.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/Eshopworld.Web.Tests/StartsResponseThrowsTestStartup.cs
+++ b/src/Tests/Eshopworld.Web.Tests/StartsResponseThrowsTestStartup.cs
@@ -12,7 +12,7 @@ namespace Eshopworld.Web.Tests
     {
         internal static readonly BigBrother Bb = new BigBrother("", "");
 
-        public StartsResponseThrowsTestStartup(IHostingEnvironment env)
+        public StartsResponseThrowsTestStartup(IWebHostEnvironment env)
         {
         }
 
@@ -22,7 +22,7 @@ namespace Eshopworld.Web.Tests
             return services.BuildServiceProvider();
         }
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             app.UseBigBrotherExceptionHandler();
 

--- a/src/Tests/Eshopworld.Web.Tests/TypeNameHelperTest.cs
+++ b/src/Tests/Eshopworld.Web.Tests/TypeNameHelperTest.cs
@@ -13,7 +13,7 @@ namespace Eshopworld.Web.Tests
     /// </remarks>
     public class TypeNameHelperTest
     {
-        [Theory, IsUnit]
+        [Theory, IsLayer0]
         // Predefined Types
         [InlineData(typeof(int), "int")]
         [InlineData(typeof(List<int>), "System.Collections.Generic.List<int>")]
@@ -51,7 +51,7 @@ namespace Eshopworld.Web.Tests
             Assert.Equal(expected, TypeNameHelper.GetTypeDisplayName(type));
         }
 
-        [Fact, IsUnit]
+        [Fact, IsLayer0]
         public void DoesNotPrintNamespace_ForGenericTypes_IfNullOrEmpty()
         {
             // Arrange
@@ -61,7 +61,7 @@ namespace Eshopworld.Web.Tests
             Assert.Equal("ClassInGlobalNamespace<int>", TypeNameHelper.GetTypeDisplayName(type));
         }
 
-        [Theory, IsUnit]
+        [Theory, IsLayer0]
         // Predefined Types
         [InlineData(typeof(int), "int")]
         [InlineData(typeof(List<int>), "List<int>")]
@@ -86,7 +86,7 @@ namespace Eshopworld.Web.Tests
             Assert.Equal(expected, TypeNameHelper.GetTypeDisplayName(type, false));
         }
 
-        [Theory, IsUnit]
+        [Theory, IsLayer0]
         [InlineData(typeof(void), "void")]
         [InlineData(typeof(bool), "bool")]
         [InlineData(typeof(byte), "byte")]
@@ -108,7 +108,7 @@ namespace Eshopworld.Web.Tests
             Assert.Equal(expected, TypeNameHelper.GetTypeDisplayName(type));
         }
 
-        [Theory, IsUnit]
+        [Theory, IsLayer0]
         [InlineData(typeof(int[]), true, "int[]")]
         [InlineData(typeof(string[][]), true, "string[][]")]
         [InlineData(typeof(int[,]), true, "int[,]")]
@@ -173,7 +173,7 @@ namespace Eshopworld.Web.Tests
             };
         }
 
-        [Theory, IsUnit]
+        [Theory, IsLayer0]
         [MemberData(nameof(GetOpenGenericsTestData))]
         public void Can_pretty_print_open_generics(Type type, bool fullName, string expected)
         {
@@ -189,7 +189,7 @@ namespace Eshopworld.Web.Tests
                 {  typeof(Level1<>.Level2<>),"Eshopworld.Web.Tests.TypeNameHelperTest+Level1<T1>+Level2<T2>" },
             };
 
-        [Theory, IsUnit]
+        [Theory, IsLayer0]
         [MemberData(nameof(GetTypeDisplayName_IncludesGenericParameterNamesWhenOptionIsSetData))]
         public void GetTypeDisplayName_IncludesGenericParameterNamesWhenOptionIsSet(Type type, string expected)
         {
@@ -209,7 +209,7 @@ namespace Eshopworld.Web.Tests
                 {  typeof(Level1<>.Level2<>),"Level2<T2>" },
             };
 
-        [Theory, IsUnit]
+        [Theory, IsLayer0]
         [MemberData(nameof(GetTypeDisplayName_WithoutFullName_IncludesGenericParameterNamesWhenOptionIsSetData))]
         public void GetTypeDisplayName_WithoutFullName_IncludesGenericParameterNamesWhenOptionIsSet(Type type, string expected)
         {
@@ -250,7 +250,7 @@ namespace Eshopworld.Web.Tests
             }
         }
 
-        [Theory, IsUnit]
+        [Theory, IsLayer0]
         [MemberData(nameof(FullTypeNameData))]
         public void Can_PrettyPrint_FullTypeName_WithoutGenericParametersAndNestedTypeDelimiter(Type type, string expectedTypeName)
         {

--- a/src/Tests/Eshopworld.Web.Tests/TypeNameHelperTest.cs
+++ b/src/Tests/Eshopworld.Web.Tests/TypeNameHelperTest.cs
@@ -1,0 +1,308 @@
+﻿using System;
+using System.Collections.Generic;
+using Eshopworld.Tests.Core;
+using Xunit;
+
+namespace Eshopworld.Web.Tests
+{
+    /// <summary>
+    /// TypeNameHelperTest has been moved from 'https://github.com/dotnet/extensions/blob/master/src/Shared/test/TypeNameHelperTest.cs'.
+    /// </summary>
+    /// <remarks>
+    /// It has been decided to copy this file for backward compatibility. See the remarks for <see cref="TypeNameHelper"/>. Namespaces were changed.
+    /// </remarks>
+    public class TypeNameHelperTest
+    {
+        [Theory, IsUnit]
+        // Predefined Types
+        [InlineData(typeof(int), "int")]
+        [InlineData(typeof(List<int>), "System.Collections.Generic.List<int>")]
+        [InlineData(typeof(Dictionary<int, string>), "System.Collections.Generic.Dictionary<int, string>")]
+        [InlineData(typeof(Dictionary<int, List<string>>), "System.Collections.Generic.Dictionary<int, System.Collections.Generic.List<string>>")]
+        [InlineData(typeof(List<List<string>>), "System.Collections.Generic.List<System.Collections.Generic.List<string>>")]
+        // Classes inside NonGeneric class
+        [InlineData(typeof(A),
+            "Eshopworld.Web.Tests.TypeNameHelperTest+A")]
+        [InlineData(typeof(B<int>),
+            "Eshopworld.Web.Tests.TypeNameHelperTest+B<int>")]
+        [InlineData(typeof(C<int, string>),
+            "Eshopworld.Web.Tests.TypeNameHelperTest+C<int, string>")]
+        [InlineData(typeof(B<B<string>>),
+            "Eshopworld.Web.Tests.TypeNameHelperTest+B<Eshopworld.Web.Tests.TypeNameHelperTest+B<string>>")]
+        [InlineData(typeof(C<int, B<string>>),
+            "Eshopworld.Web.Tests.TypeNameHelperTest+C<int, Eshopworld.Web.Tests.TypeNameHelperTest+B<string>>")]
+        // Classes inside Generic class
+        [InlineData(typeof(Outer<int>.D),
+            "Eshopworld.Web.Tests.TypeNameHelperTest+Outer<int>+D")]
+        [InlineData(typeof(Outer<int>.E<int>),
+            "Eshopworld.Web.Tests.TypeNameHelperTest+Outer<int>+E<int>")]
+        [InlineData(typeof(Outer<int>.F<int, string>),
+            "Eshopworld.Web.Tests.TypeNameHelperTest+Outer<int>+F<int, string>")]
+        [InlineData(typeof(Level1<int>.Level2<bool>.Level3<int>),
+            "Eshopworld.Web.Tests.TypeNameHelperTest+Level1<int>+Level2<bool>+Level3<int>")]
+        [InlineData(typeof(Outer<int>.E<Outer<int>.E<string>>),
+            "Eshopworld.Web.Tests.TypeNameHelperTest+Outer<int>+E<Eshopworld.Web.Tests.TypeNameHelperTest+Outer<int>+E<string>>")]
+        [InlineData(typeof(Outer<int>.F<int, Outer<int>.E<string>>),
+            "Eshopworld.Web.Tests.TypeNameHelperTest+Outer<int>+F<int, Eshopworld.Web.Tests.TypeNameHelperTest+Outer<int>+E<string>>")]
+        [InlineData(typeof(OuterGeneric<int>.InnerNonGeneric.InnerGeneric<int, string>.InnerGenericLeafNode<bool>),
+            "Eshopworld.Web.Tests.TypeNameHelperTest+OuterGeneric<int>+InnerNonGeneric+InnerGeneric<int, string>+InnerGenericLeafNode<bool>")]
+        public void Can_pretty_print_CLR_full_name(Type type, string expected)
+        {
+            Assert.Equal(expected, TypeNameHelper.GetTypeDisplayName(type));
+        }
+
+        [Fact, IsUnit]
+        public void DoesNotPrintNamespace_ForGenericTypes_IfNullOrEmpty()
+        {
+            // Arrange
+            var type = typeof(ClassInGlobalNamespace<int>);
+
+            // Act & Assert
+            Assert.Equal("ClassInGlobalNamespace<int>", TypeNameHelper.GetTypeDisplayName(type));
+        }
+
+        [Theory, IsUnit]
+        // Predefined Types
+        [InlineData(typeof(int), "int")]
+        [InlineData(typeof(List<int>), "List<int>")]
+        [InlineData(typeof(Dictionary<int, string>), "Dictionary<int, string>")]
+        [InlineData(typeof(Dictionary<int, List<string>>), "Dictionary<int, List<string>>")]
+        [InlineData(typeof(List<List<string>>), "List<List<string>>")]
+        // Classes inside NonGeneric class
+        [InlineData(typeof(A), "A")]
+        [InlineData(typeof(B<int>), "B<int>")]
+        [InlineData(typeof(C<int, string>), "C<int, string>")]
+        [InlineData(typeof(C<int, B<string>>), "C<int, B<string>>")]
+        [InlineData(typeof(B<B<string>>), "B<B<string>>")]
+        // Classes inside Generic class
+        [InlineData(typeof(Outer<int>.D), "D")]
+        [InlineData(typeof(Outer<int>.E<int>), "E<int>")]
+        [InlineData(typeof(Outer<int>.F<int, string>), "F<int, string>")]
+        [InlineData(typeof(Outer<int>.F<int, Outer<int>.E<string>>), "F<int, E<string>>")]
+        [InlineData(typeof(Outer<int>.E<Outer<int>.E<string>>), "E<E<string>>")]
+        [InlineData(typeof(OuterGeneric<int>.InnerNonGeneric.InnerGeneric<int, string>.InnerGenericLeafNode<bool>), "InnerGenericLeafNode<bool>")]
+        public void Can_pretty_print_CLR_name(Type type, string expected)
+        {
+            Assert.Equal(expected, TypeNameHelper.GetTypeDisplayName(type, false));
+        }
+
+        [Theory, IsUnit]
+        [InlineData(typeof(void), "void")]
+        [InlineData(typeof(bool), "bool")]
+        [InlineData(typeof(byte), "byte")]
+        [InlineData(typeof(char), "char")]
+        [InlineData(typeof(decimal), "decimal")]
+        [InlineData(typeof(double), "double")]
+        [InlineData(typeof(float), "float")]
+        [InlineData(typeof(int), "int")]
+        [InlineData(typeof(long), "long")]
+        [InlineData(typeof(object), "object")]
+        [InlineData(typeof(sbyte), "sbyte")]
+        [InlineData(typeof(short), "short")]
+        [InlineData(typeof(string), "string")]
+        [InlineData(typeof(uint), "uint")]
+        [InlineData(typeof(ulong), "ulong")]
+        [InlineData(typeof(ushort), "ushort")]
+        public void Returns_common_name_for_built_in_types(Type type, string expected)
+        {
+            Assert.Equal(expected, TypeNameHelper.GetTypeDisplayName(type));
+        }
+
+        [Theory, IsUnit]
+        [InlineData(typeof(int[]), true, "int[]")]
+        [InlineData(typeof(string[][]), true, "string[][]")]
+        [InlineData(typeof(int[,]), true, "int[,]")]
+        [InlineData(typeof(bool[,,,]), true, "bool[,,,]")]
+        [InlineData(typeof(A[,][,,]), true, "Eshopworld.Web.Tests.TypeNameHelperTest+A[,][,,]")]
+        [InlineData(typeof(List<int[,][,,]>), true, "System.Collections.Generic.List<int[,][,,]>")]
+        [InlineData(typeof(List<int[,,][,]>[,][,,]), false, "List<int[,,][,]>[,][,,]")]
+        public void Can_pretty_print_array_name(Type type, bool fullName, string expected)
+        {
+            Assert.Equal(expected, TypeNameHelper.GetTypeDisplayName(type, fullName));
+        }
+
+        public static TheoryData GetOpenGenericsTestData()
+        {
+            var openDictionaryType = typeof(Dictionary<,>);
+            var genArgsDictionary = openDictionaryType.GetGenericArguments();
+            genArgsDictionary[0] = typeof(B<>);
+            var closedDictionaryType = openDictionaryType.MakeGenericType(genArgsDictionary);
+
+            var openLevelType = typeof(Level1<>.Level2<>.Level3<>);
+            var genArgsLevel = openLevelType.GetGenericArguments();
+            genArgsLevel[1] = typeof(string);
+            var closedLevelType = openLevelType.MakeGenericType(genArgsLevel);
+
+            var openInnerType = typeof(OuterGeneric<>.InnerNonGeneric.InnerGeneric<,>.InnerGenericLeafNode<>);
+            var genArgsInnerType = openInnerType.GetGenericArguments();
+            genArgsInnerType[3] = typeof(bool);
+            var closedInnerType = openInnerType.MakeGenericType(genArgsInnerType);
+
+            return new TheoryData<Type, bool, string>
+            {
+                { typeof(List<>), false, "List<>" },
+                { typeof(Dictionary<,>), false , "Dictionary<,>" },
+                { typeof(List<>), true , "System.Collections.Generic.List<>" },
+                { typeof(Dictionary<,>), true , "System.Collections.Generic.Dictionary<,>" },
+                { typeof(Level1<>.Level2<>.Level3<>), true, "Eshopworld.Web.Tests.TypeNameHelperTest+Level1<>+Level2<>+Level3<>" },
+                {
+                    typeof(PartiallyClosedGeneric<>).BaseType,
+                    true,
+                    "Eshopworld.Web.Tests.TypeNameHelperTest+C<, int>"
+                },
+                {
+                    typeof(OuterGeneric<>.InnerNonGeneric.InnerGeneric<,>.InnerGenericLeafNode<>),
+                    true,
+                    "Eshopworld.Web.Tests.TypeNameHelperTest+OuterGeneric<>+InnerNonGeneric+InnerGeneric<,>+InnerGenericLeafNode<>"
+                },
+                {
+                    closedDictionaryType,
+                    true,
+                    "System.Collections.Generic.Dictionary<Eshopworld.Web.Tests.TypeNameHelperTest+B<>,>"
+                },
+                {
+                    closedLevelType,
+                    true,
+                    "Eshopworld.Web.Tests.TypeNameHelperTest+Level1<>+Level2<string>+Level3<>"
+                },
+                {
+                    closedInnerType,
+                    true,
+                    "Eshopworld.Web.Tests.TypeNameHelperTest+OuterGeneric<>+InnerNonGeneric+InnerGeneric<,>+InnerGenericLeafNode<bool>"
+                }
+            };
+        }
+
+        [Theory, IsUnit]
+        [MemberData(nameof(GetOpenGenericsTestData))]
+        public void Can_pretty_print_open_generics(Type type, bool fullName, string expected)
+        {
+            Assert.Equal(expected, TypeNameHelper.GetTypeDisplayName(type, fullName));
+        }
+
+        public static TheoryData GetTypeDisplayName_IncludesGenericParameterNamesWhenOptionIsSetData =>
+            new TheoryData<Type, string>
+            {
+                {  typeof(B<>),"Eshopworld.Web.Tests.TypeNameHelperTest+B<T>" },
+                {  typeof(C<,>),"Eshopworld.Web.Tests.TypeNameHelperTest+C<T1, T2>" },
+                {  typeof(PartiallyClosedGeneric<>).BaseType,"Eshopworld.Web.Tests.TypeNameHelperTest+C<T, int>" },
+                {  typeof(Level1<>.Level2<>),"Eshopworld.Web.Tests.TypeNameHelperTest+Level1<T1>+Level2<T2>" },
+            };
+
+        [Theory, IsUnit]
+        [MemberData(nameof(GetTypeDisplayName_IncludesGenericParameterNamesWhenOptionIsSetData))]
+        public void GetTypeDisplayName_IncludesGenericParameterNamesWhenOptionIsSet(Type type, string expected)
+        {
+            // Arrange & Act
+            var actual = TypeNameHelper.GetTypeDisplayName(type, fullName: true, includeGenericParameterNames: true);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        public static TheoryData GetTypeDisplayName_WithoutFullName_IncludesGenericParameterNamesWhenOptionIsSetData =>
+            new TheoryData<Type, string>
+            {
+                {  typeof(B<>),"B<T>" },
+                {  typeof(C<,>),"C<T1, T2>" },
+                {  typeof(PartiallyClosedGeneric<>).BaseType,"C<T, int>" },
+                {  typeof(Level1<>.Level2<>),"Level2<T2>" },
+            };
+
+        [Theory, IsUnit]
+        [MemberData(nameof(GetTypeDisplayName_WithoutFullName_IncludesGenericParameterNamesWhenOptionIsSetData))]
+        public void GetTypeDisplayName_WithoutFullName_IncludesGenericParameterNamesWhenOptionIsSet(Type type, string expected)
+        {
+            // Arrange & Act
+            var actual = TypeNameHelper.GetTypeDisplayName(type, fullName: false, includeGenericParameterNames: true);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        public static TheoryData<Type, string> FullTypeNameData
+        {
+            get
+            {
+                return new TheoryData<Type, string>
+                {
+                    // Predefined Types
+                    { typeof(int), "int" },
+                    { typeof(List<int>), "System.Collections.Generic.List" },
+                    { typeof(Dictionary<int, string>), "System.Collections.Generic.Dictionary" },
+                    { typeof(Dictionary<int, List<string>>), "System.Collections.Generic.Dictionary" },
+                    { typeof(List<List<string>>), "System.Collections.Generic.List" },
+
+                    // Classes inside NonGeneric class
+                    { typeof(A), "Eshopworld.Web.Tests.TypeNameHelperTest.A" },
+                    { typeof(B<int>), "Eshopworld.Web.Tests.TypeNameHelperTest.B" },
+                    { typeof(C<int, string>), "Eshopworld.Web.Tests.TypeNameHelperTest.C" },
+                    { typeof(C<int, B<string>>), "Eshopworld.Web.Tests.TypeNameHelperTest.C" },
+                    { typeof(B<B<string>>), "Eshopworld.Web.Tests.TypeNameHelperTest.B" },
+
+                    // Classes inside Generic class
+                    { typeof(Outer<int>.D), "Eshopworld.Web.Tests.TypeNameHelperTest.Outer.D" },
+                    { typeof(Outer<int>.E<int>), "Eshopworld.Web.Tests.TypeNameHelperTest.Outer.E" },
+                    { typeof(Outer<int>.F<int, string>), "Eshopworld.Web.Tests.TypeNameHelperTest.Outer.F" },
+                    { typeof(Outer<int>.F<int, Outer<int>.E<string>>),"Eshopworld.Web.Tests.TypeNameHelperTest.Outer.F" },
+                    { typeof(Outer<int>.E<Outer<int>.E<string>>), "Eshopworld.Web.Tests.TypeNameHelperTest.Outer.E" }
+                };
+            }
+        }
+
+        [Theory, IsUnit]
+        [MemberData(nameof(FullTypeNameData))]
+        public void Can_PrettyPrint_FullTypeName_WithoutGenericParametersAndNestedTypeDelimiter(Type type, string expectedTypeName)
+        {
+            // Arrange & Act
+            var displayName = TypeNameHelper.GetTypeDisplayName(type, fullName: true, includeGenericParameters: false, nestedTypeDelimiter: '.');
+
+            // Assert
+            Assert.Equal(expectedTypeName, displayName);
+        }
+
+        private class A { }
+
+        private class B<T> { }
+
+        private class C<T1, T2> { }
+
+        private class PartiallyClosedGeneric<T> : C<T, int> { }
+
+        private class Outer<T>
+        {
+            public class D { }
+
+            public class E<T1> { }
+
+            public class F<T1, T2> { }
+        }
+
+        private class OuterGeneric<T1>
+        {
+            public class InnerNonGeneric
+            {
+                public class InnerGeneric<T2, T3>
+                {
+                    public class InnerGenericLeafNode<T4> { }
+
+                    public class InnerLeafNode { }
+                }
+            }
+        }
+
+        private class Level1<T1>
+        {
+            public class Level2<T2>
+            {
+                public class Level3<T3>
+                {
+                }
+            }
+        }
+    }
+}
+
+internal class ClassInGlobalNamespace<T>
+{
+}

--- a/src/global.json
+++ b/src/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "2.2.401"
+    "version": "3.1.102",
+	"rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
### What
Migrate eShopWorld.Web package to .NET Core 3.1

### Why
All our packages are being moved to .NET Core 3.1. This package, in particular, is also changed from .NET Standard to .NET Core App, since it has ASP.NET Core dependencies.