### PR TITLE
Updates for RP in Fabric to bind to IP Nic

### DIFF
--- a/src/Eshopworld.Web/Eshopworld.Web.csproj
+++ b/src/Eshopworld.Web/Eshopworld.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>4.0.1</Version>
+    <Version>4.1.0</Version>
     <PackageReleaseNotes>
       Downgrade of Microsoft.Extensions.Configuration.AzureKeyVault
     </PackageReleaseNotes>

--- a/src/Eshopworld.Web/Eshopworld.Web.csproj
+++ b/src/Eshopworld.Web/Eshopworld.Web.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Version>4.1.0</Version>
     <PackageReleaseNotes>
-      Downgrade of Microsoft.Extensions.Configuration.AzureKeyVault
+      Update to support SSL certificate binding in Kestrel for the Service Fabric Reverse Proxy. 
     </PackageReleaseNotes>
 
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/src/Eshopworld.Web/EswSslExtentions.cs
+++ b/src/Eshopworld.Web/EswSslExtentions.cs
@@ -65,7 +65,7 @@ namespace Eshopworld.Web
                 // TODO: this is a simple solution to solve a temporary problem. Only the first endpoint is visible in SF Explorer. Better solutions are too complicated for our case.
                 foreach (var (port, isHttps) in endpoints)
                 {
-                    options.Listen(IPAddress.Any, port, listenOptions =>
+                    options.Listen(IPAddress.IPv6Any, port, listenOptions =>
                     {
                         if (isHttps)
                         {

--- a/src/Eshopworld.Web/EswSslExtentions.cs
+++ b/src/Eshopworld.Web/EswSslExtentions.cs
@@ -56,8 +56,9 @@ namespace Eshopworld.Web
         /// </summary>
         /// <param name="builder">The web host builder.</param>
         /// <param name="endpoints">The enumeration of endpoints each defined by the port number and handled protocol type.</param>
+        /// <param name="enableIpv6Binding">Switch to enable IPV6 binding - which is needed for the Service Fabric Proxy and Kestrel SSL binding to the app</param>
         /// <returns>The web builder.</returns>
-        public static IWebHostBuilder UseEswSsl(this IWebHostBuilder builder, IEnumerable<(int port, bool isHttps)> endpoints)
+        public static IWebHostBuilder UseEswSsl(this IWebHostBuilder builder, IEnumerable<(int port, bool isHttps)> endpoints, bool enableIpv6Binding = false)
         {
             return builder.ConfigureKestrel((context, options) =>
             {
@@ -65,7 +66,7 @@ namespace Eshopworld.Web
                 // TODO: this is a simple solution to solve a temporary problem. Only the first endpoint is visible in SF Explorer. Better solutions are too complicated for our case.
                 foreach (var (port, isHttps) in endpoints)
                 {
-                    options.Listen(IPAddress.IPv6Any, port, listenOptions =>
+                    options.Listen(enableIpv6Binding ? IPAddress.IPv6Any : IPAddress.Any, port, listenOptions =>
                     {
                         if (isHttps)
                         {


### PR DESCRIPTION
Update required to this library to support SSL certificate binding in Kestrel for the Service Fabric Reverse Proxy.

Note do not publish to Nuget until I have tested this against the debug package.

Ref: https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-tutorial-dotnet-app-enable-https-endpoint#configure-kestrel-to-use-https