### PR TITLE
Downgrade SF libraries

### DIFF
--- a/src/Eshopworld.Web/Eshopworld.Web.csproj
+++ b/src/Eshopworld.Web/Eshopworld.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>4.1.2</Version>
+    <Version>4.1.3</Version>
     <PackageReleaseNotes>
       Upgrade of dependency packages.
     </PackageReleaseNotes>
@@ -31,14 +31,14 @@
   
   <ItemGroup>
     <PackageReference Include="Eshopworld.Core" Version="4.1.6" />
-    <PackageReference Include="Eshopworld.DevOps" Version="5.1.4" />
+    <PackageReference Include="Eshopworld.DevOps" Version="5.1.5" />
     <PackageReference Include="Eshopworld.Telemetry" Version="3.1.5" />
     <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.14.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.7" />
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.1.428" />
-    <PackageReference Include="Microsoft.ServiceFabric.AspNetCore.Kestrel" Version="4.1.428" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.0.470" />
+    <PackageReference Include="Microsoft.ServiceFabric.AspNetCore.Kestrel" Version="4.0.470" />
     <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
     <PackageReference Include="System.Reactive" Version="4.4.1" />
   </ItemGroup>


### PR DESCRIPTION
SF libraries need to be downgraded to what they were before otherwise they will force the upstream dependency chain to upgrade to the same version which is not currently working on the company build machines.