### PR TITLE
#83938 #83942 - exclude from test coverage

### DIFF
--- a/src/Eshopworld.Web/ActorLayerTestMiddleware.cs
+++ b/src/Eshopworld.Web/ActorLayerTestMiddleware.cs
@@ -1,4 +1,6 @@
-﻿namespace Eshopworld.Web
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Eshopworld.Web
 {
     using System;
     using System.Collections.Generic;
@@ -21,6 +23,8 @@
     /// <summary>
     /// The parameters required by <see cref="ActorLayerTestMiddleware"/>;
     /// </summary>
+    /// <remarks>Excluded from code coverage as the search on ADO shows no usage by the clients.</remarks>
+    [ExcludeFromCodeCoverage]
     public class ActorLayerTestMiddlewareOptions
     {
         /// <summary>
@@ -58,6 +62,8 @@
     /// <remarks>
     /// By design only actors with a specific interface schema are supported.
     /// </remarks>
+    /// <remarks>Excluded from code coverage as the search on ADO shows no usage by the clients.</remarks>
+    [ExcludeFromCodeCoverage]
     public class ActorLayerTestMiddleware
     {
         private readonly RequestDelegate _next;

--- a/src/Eshopworld.Web/IApplicationBuilderExtensions.cs
+++ b/src/Eshopworld.Web/IApplicationBuilderExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using Eshopworld.Core;
 using Microsoft.AspNetCore.Builder;
 
@@ -17,6 +18,8 @@ namespace Eshopworld.Web
         /// </summary>
         /// <param name="app">The <see cref="IApplicationBuilder"/> to add the middleware to.</param>
         /// <param name="options">The middleware's parameters.</param>
+        /// <remarks>Excluded from code coverage as the search on ADO shows no usage by the clients.</remarks>
+        [ExcludeFromCodeCoverage]
         public static IApplicationBuilder UseActorLayerTestDirectCall(this IApplicationBuilder app, ActorLayerTestMiddlewareOptions options)
         {
             if (options == null)
@@ -53,6 +56,8 @@ namespace Eshopworld.Web
         /// </summary>
         /// <param name="app">The <see cref="IApplicationBuilder"/> to add the middleware to.</param>
         /// <param name="options">The middleware's parameters.</param>
+        /// <remarks>Excluded from code coverage as the search on ADO shows no usage by the clients.</remarks>
+        [ExcludeFromCodeCoverage]
         public static IObservable<BaseNotification> UseNotification(this IApplicationBuilder app,
             NotificationChannelMiddlewareOptions options)
         {


### PR DESCRIPTION
The excluded code is not used by the clients as checked via ADO cross-repo search. The cost of test coverage is high though due to advanced code in ActorLayerTestMiddleware.