### PR TITLE
#83932 Exclude RequestTelemetryInitializer from code coverage

### DIFF
--- a/src/Eshopworld.Web/Telemetry/RequestTelemetryInitializer.cs
+++ b/src/Eshopworld.Web/Telemetry/RequestTelemetryInitializer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 using Eshopworld.Core;
@@ -11,6 +12,7 @@ using Microsoft.AspNetCore.Http;
 namespace Eshopworld.Web.Telemetry
 {
     /// <summary>Allows interception of AI RequestTelemetry events and exposes request body</summary>
+    [ExcludeFromCodeCoverage]
     public class RequestTelemetryInitializer : ITelemetryInitializer
     {
         private readonly IHttpContextAccessor _httpContextAccessor;

--- a/src/Eshopworld.Web/Telemetry/RequestTelemetryInitializer.cs
+++ b/src/Eshopworld.Web/Telemetry/RequestTelemetryInitializer.cs
@@ -21,7 +21,7 @@ namespace Eshopworld.Web.Telemetry
         /// <summary>Default ctor</summary>
         /// <param name="httpContextAccessor">HttpContextAccessor to resolve the http request</param>
         /// <param name="bigBrother">BigBrother used for logging</param>
-        public RequestTelemetryInitializer([NotNull] IHttpContextAccessor httpContextAccessor, [NotNull] IBigBrother bigBrother)
+        public RequestTelemetryInitializer([JetBrains.Annotations.NotNull] IHttpContextAccessor httpContextAccessor, [JetBrains.Annotations.NotNull] IBigBrother bigBrother)
         {
             _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
             _bigBrother = bigBrother ?? throw new ArgumentNullException(nameof(bigBrother));


### PR DESCRIPTION
The RequestTelemetryInitializer class is not used by any other team at the moment so due to the nature of the class itself we are excluding it from coverage.